### PR TITLE
export openSearchSecGrp security group id

### DIFF
--- a/lib/aws-opensearch-serverless-stack.ts
+++ b/lib/aws-opensearch-serverless-stack.ts
@@ -141,5 +141,12 @@ export class AwsOpensearchServerlessStack extends cdk.Stack {
       exportName: `${props.resourcePrefix}-OpenSearch-KMS-Key-Arn`,
       description: 'OpenSearch KMS Key Arn',
     });
+
+    // export openSearchSecGrp security group id
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-OpenSearch-Security-Group-Id-Output`, {
+      value: openSearchSecGrp.securityGroupId,
+      exportName: `${props.resourcePrefix}-OpenSearch-Security-Group-Id`,
+      description: 'OpenSearch Security Group Id',
+    });
   }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement

___

### **PR Description**
- Exports the OpenSearch security group ID as a CloudFormation output.

- Maintains consistency with existing KMS key exports.
